### PR TITLE
use globalAgent when in lambda

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2951,6 +2951,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "http-cache-semantics": "^3.8.1",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
+    "is-lambda": "1.0.1",
     "lru-cache": "^5.1.1",
     "minipass": "^3.0.0",
     "minipass-collect": "^1.0.2",

--- a/test/lambda-agent.js
+++ b/test/lambda-agent.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const test = require('tap').test
+const requireInject = require('require-inject')
+
+const http = require('http')
+const https = require('https')
+
+const MockHttp = mockHttpAgent('http')
+
+MockHttp.HttpsAgent = mockHttpAgent('https')
+
+const agent = requireInject.installGlobally('../agent.js', {
+  'is-lambda': true,
+  'agentkeepalive': MockHttp,
+  'https-proxy-agent': mockHttpAgent('https-proxy')
+})
+
+function mockHttpAgent (type) {
+  return function Agent (opts) {
+    return Object.assign({}, opts, { __type: type })
+  }
+}
+
+const OPTS = {
+  agent: null,
+  maxSockets: 5,
+  ca: 'ca',
+  cert: 'cert',
+  key: 'key',
+  localAddress: 'localAddress',
+  strictSSL: 'strictSSL',
+  timeout: 5
+}
+
+test('extracts process env variables', t => {
+  process.env = { TEST_ENV: 'test', ANOTHER_ENV: 'no' }
+
+  t.deepEqual(agent.getProcessEnv('test_ENV'), 'test', 'extracts single env')
+
+  t.deepEqual(
+    agent.getProcessEnv(['not_existing_env', 'test_ENV', 'another_env']),
+    'test',
+    'extracts env from array of env names'
+  )
+  t.done()
+})
+
+test('global http agent when lambda', t => {
+  t.deepEqual(agent('http://foo.com/bar', OPTS), http.globalAgent)
+  t.done()
+})
+
+test('global https agent when lambda', t => {
+  t.deepEqual(agent('https://foo.com/bar', OPTS), https.globalAgent)
+  t.done()
+})
+
+test('all expected options passed down to proxy agent', t => {
+  const opts = Object.assign({
+    proxy: 'https://user:pass@my.proxy:1234/foo'
+  }, OPTS)
+  t.deepEqual(agent('https://foo.com/bar', opts), {
+    __type: 'https-proxy',
+    host: 'my.proxy',
+    port: '1234',
+    protocol: 'https:',
+    path: '/foo',
+    auth: 'user:pass',
+    ca: 'ca',
+    cert: 'cert',
+    key: 'key',
+    maxSockets: 5,
+    localAddress: 'localAddress',
+    rejectUnauthorized: 'strictSSL',
+    timeout: 6
+  }, 'only expected options passed to https proxy')
+  t.done()
+})


### PR DESCRIPTION
When using this library in a AWS Lambda new keep alive connections are created on each new lambda instance and not disposed of.

The sockets were sometimes disposed of prior to [AWS Hyperplane](https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/). With hyperplane network interfaces are shared by all lambdas, keep alive only makes sense if making many requests and only if the agent was then disposed before exit.

This `PR` makes the default behavior for AWS Lambda to use `globalAgent` instead, I have verified that using the global agent doesn't leak resources.

Passing a customer agent and or proxy will work as before.