### PR TITLE
fix: broken `memoize` logic @ v6

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -65,10 +65,10 @@ module.exports = class Cache {
         // avoid opening cache file handles until a user actually tries to
         // read from it.
         const body = new Minipass()
-        const notFitInMemory = false && info.size > MAX_MEM_SIZE
+        const fitInMemory = info.size < MAX_MEM_SIZE
         const removeOnResume = () => body.removeListener('resume', onResume)
         const onResume =
-          opts.memoize !== notFitInMemory
+          opts.memoize !== false && fitInMemory
             ? () => {
               const c = cacache.get.stream.byDigest(cachePath, info.integrity, {
                 memoize: opts.memoize


### PR DESCRIPTION
Changes condition/logic of `fitInMemory` used when defining `memoize`