### PR TITLE
fix: remoteFetch takes instance of fetch.Headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,17 +265,22 @@ function remoteFetchHandleIntegrity (res, integrity) {
 
 function remoteFetch (uri, opts) {
   const agent = getAgent(uri, opts)
-  const headers = Object.assign({
-    connection: agent ? 'keep-alive' : 'close',
-    'user-agent': USER_AGENT
-  }, opts.headers || {})
+  const headers = opts.headers instanceof fetch.Headers
+    ? opts.headers
+    : new fetch.Headers(opts.headers)
+  if (!headers.get('connection')) {
+    headers.set('connection', agent ? 'keep-alive' : 'close')
+  }
+  if (!headers.get('user-agent')) {
+    headers.set('user-agent', USER_AGENT)
+  }
 
   const reqOpts = {
     agent,
     body: opts.body,
     compress: opts.compress,
     follow: opts.follow,
-    headers: new fetch.Headers(headers),
+    headers,
     method: opts.method,
     redirect: 'manual',
     size: opts.size,

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Response } = require('minipass-fetch')
+const { Response, Headers } = require('minipass-fetch')
 const requireInject = require('require-inject')
 const { Buffer } = require('safe-buffer')
 const Minipass = require('minipass')
@@ -241,6 +241,25 @@ test('custom headers', t => {
       }
     })
   return fetch(`${HOST}/test`, { headers: { test: 'ayy' } })
+    .then(res => {
+      t.equal(res.headers.get('foo'), 'bar', 'got response header')
+    })
+})
+
+test('custom headers (class)', t => {
+  const fetch = mockRequire({})
+  const srv = tnock(t, HOST)
+
+  srv
+    .get('/test')
+    .reply(200, CONTENT, {
+      foo: (req) => {
+        t.equal(req.headers.test[0], 'ayy', 'got request header')
+        return 'bar'
+      }
+    })
+
+  return fetch(`${HOST}/test`, { headers: new Headers({ test: 'ayy' }) })
     .then(res => {
       t.equal(res.headers.get('foo'), 'bar', 'got response header')
     })


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
While `fetch` can take an instance of Headers, doing so here will cause undefined behavior because `Object.assign({ header: "value" }, Header);` results in `{ header: "value", [Symbol.Map]: { header: ["value"] } }`