### PR TITLE
fix: Keep exports the same as `node-fetch`

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,11 @@ const RETRY_TYPES = [
 ]
 
 // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
-module.exports = cachingFetch
+module.exports = exports = cachingFetch
+exports.Headers = fetch.Headers
+exports.Request = fetch.Request
+exports.Response = fetch.Response
+exports.FetchError = fetch.FetchError
 cachingFetch.defaults = function (_uri, _opts) {
   const fetch = this
   if (typeof _uri === 'object') {

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,0 +1,19 @@
+const { Headers, Request, Response, FetchError } = require('../')
+const fetch = require('minipass-fetch')
+const { test } = require('tap')
+
+test('exports the same helper classes', t => {
+  t.equal(Headers, fetch.Headers)
+  t.match(Headers, Function)
+
+  t.equal(Request, fetch.Request)
+  t.match(Request, Function)
+
+  t.equal(Response, fetch.Response)
+  t.match(Response, Function)
+
+  t.equal(FetchError, fetch.FetchError)
+  t.match(FetchError, Function)
+
+  t.end()
+})


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
If this package is a super set of `node-fetch` (well `minipass-fetch`) it should share the same exports. Furthermore, trying to test this package against `node-fetch` classes fails because it is obscure that this uses a fork of that module.