### PR TITLE
feat: deep defaulting of headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const pkg = require('./package.json')
 const retry = require('promise-retry')
 let ssri
 
+const { Headers } = require('minipass-fetch')
 const Minipass = require('minipass')
 const MinipassPipeline = require('minipass-pipeline')
 const getAgent = require('./agent')
@@ -41,7 +42,18 @@ cachingFetch.defaults = function (_uri, _opts) {
   }
 
   function defaultedFetch (uri, opts) {
-    const finalOpts = Object.assign({}, _opts || {}, opts || {})
+    const defaultOpts = _opts || {}
+    const invokeOpts = opts || {}
+    const finalOpts = Object.assign({}, defaultOpts, invokeOpts)
+
+    finalOpts.headers = new Headers()
+    for (const defaultHeader of new Headers(defaultOpts.headers).entries()) {
+      finalOpts.headers.set(defaultHeader[0], defaultHeader[1])
+    }
+    for (const invokeHeader of new Headers(invokeOpts.headers).entries()) {
+      finalOpts.headers.set(invokeHeader[0], invokeHeader[1])
+    }
+
     return fetch(uri || _uri, finalOpts)
   }
 

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -265,6 +265,26 @@ test('custom headers (class)', t => {
     })
 })
 
+test('custom headers layering with defaults', t => {
+  const fetch = mockRequire({}).defaults({ headers: { foo: '1', baz: '3' } })
+  const srv = tnock(t, HOST)
+
+  srv
+    .get('/test')
+    .reply(200, CONTENT, {
+      foo: (req) => {
+        t.equal(req.headers.foo[0], '1', 'got request header from defaults')
+        t.equal(req.headers.bar[0], '2', 'got request header from invocation')
+        t.equal(req.headers.baz[0], '0', 'got request header invocation overriding defaults')
+        return 'bar'
+      }
+    })
+  return fetch(`${HOST}/test`, { headers: { bar: '2', baz: '0' } })
+    .then(res => {
+      t.equal(res.headers.get('foo'), 'bar', 'got response header')
+    })
+})
+
 test('supports redirect logic', t => {
   const fetch = mockRequire({})
 


### PR DESCRIPTION
Instead of overwriting headers set in defaults with headers set in the invocation of fetch, layer the two with the headers set in the invocation taking priority over the default headers.

# What / Why

In `defaultedFetch` in `index.js` ([src](https://github.com/npm/make-fetch-happen/blob/latest/index.js#L44)), the defaulting is done with `Object.assign({}, _opts || {}, opts || {})`

This is a problem if `headers` are specified in the defaults *and* the invocation because the default `headers` object gets overridden.

Take this example:

```
const customFetch = fetch.defaults({
    headers: {
        'X-Request-Id': uuid.v3(),
    }
});

customFetch(url, {
    headers: {
        Accept: 'application/json'
    }
}).then(...);
```
`Accept` is sent with the request but not `X-Request-Id`.

This pull request merges the defaulted headers with the headers from the invocation of `fetch()`.

## References

* Related to #25 
