### PR TITLE
Introduce TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,12 @@
 import { ClientRequestArgs, AgentOptions } from "http";
 import { SecureContextOptions, CommonConnectionOptions } from "tls";
-import { RequestInit } from "node-fetch";
+import {
+  RequestInit,
+  Headers,
+  Request,
+  Response,
+  FetchError,
+} from "node-fetch";
 import { TimeoutsOptions } from "retry";
 import { Integrity } from "ssri";
 
@@ -42,3 +48,12 @@ interface CachingFetch {
 }
 
 export default CachingFetch;
+
+export {
+  CachingFetch,
+  CachingFetchOpts,
+  Headers,
+  Request,
+  Response,
+  FetchError,
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,44 @@
+import { ClientRequestArgs, AgentOptions } from "http";
+import { SecureContextOptions, CommonConnectionOptions } from "tls";
+import { RequestInit } from "node-fetch";
+import { TimeoutsOptions } from "retry";
+import { Integrity } from "ssri";
+
+type NodeFetchOpts = Pick<
+  RequestInit,
+  "method" | "body" | "redirect" | "follow" | "timeout" | "compress" | "size"
+>;
+
+type TlsOpts = Pick<SecureContextOptions, "ca" | "cert" | "key"> & {
+  strictSSL?: CommonConnectionOptions["rejectUnauthorized"];
+};
+
+type MakeFetchHappenOpts = {
+  cacheManager?: string | Cache;
+  cache?:
+    | "default"
+    | "no-store"
+    | "reload"
+    | "no-cache"
+    | "force-cache"
+    | "only-if-cached";
+  // TODO: is URL correct here?
+  proxy?: string | URL;
+  noProxy?: string | string[];
+  localAddress?: ClientRequestArgs["localAddress"];
+  maxSockets?: AgentOptions["maxSockets"];
+  retry?: boolean | number | TimeoutsOptions;
+  onRetry?: () => any;
+  // may either be a string or an ssri Integrity-like
+  integrity?: string | Integrity;
+};
+
+type CachingFetchOpts = NodeFetchOpts & TlsOpts & MakeFetchHappenOpts;
+
+interface CachingFetch {
+  (uriOrRequest: string | Request, opts?: CachingFetchOpts): Promise<Response>;
+  defaults(uri: string, opts?: CachingFetchOpts): CachingFetch;
+  defaults(opts: CachingFetchOpts): CachingFetch;
+}
+
+export default CachingFetch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,6 +202,50 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "dev": true
+    },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
+    "@types/ssri": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ssri/-/ssri-7.1.0.tgz",
+      "integrity": "sha512-CJR8I0rHwuhpS6YBq1q+StUlQBuxoyfVVZ3O1FDiXH1HJtNm90lErBsZpr2zBMF2x5d9khvq105CQ03EXkZzAQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "twitter": "maybekatz"
   },
   "license": "ISC",
+  "types": "./index.d.ts",
   "dependencies": {
     "agentkeepalive": "^4.1.0",
     "cacache": "^15.0.0",
@@ -50,6 +51,9 @@
     "ssri": "^8.0.0"
   },
   "devDependencies": {
+    "@types/node-fetch": "^2.5.7",
+    "@types/retry": "^0.12.0",
+    "@types/ssri": "^7.1.0",
     "mkdirp": "^1.0.3",
     "nock": "^11.9.1",
     "npmlog": "^4.1.2",


### PR DESCRIPTION
# What / Why
This PR intends to introduce TypeScript type definitions for this package. Currently Apollo (and other users, based on the 👍 emojis on #20) are really enjoying what `make-fetch-happen` has to offer! For those of us using TypeScript, we're currently [rolling our own](https://github.com/apollographql/apollo-server/pull/4333) and its far from ideal. We recently ran into trouble in doing so as you can see in my linked PR.

I asked the maintainers awhile back (#20) if they'd be willing to accept a PR, but I received no response. I'm hopeful we can land them here, else I'm happy to take them (or someone else can!) over to `DefinitelyTyped`.

I did my best based on the API documentation (which is quite thorough!). But please scrutinize the types which I've imported, as this package depends on libs such as `minipass-fetch` which in turn depends on `node-fetch`. I chose to depend on those types directly rather than copy them over in order to more easily land updates which may come in the future.

Thanks for your consideration!

Fixes #20
cc @abernix