### PR TITLE
Include query string in cache key

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -20,7 +20,8 @@ function cacheKey (req) {
       slashes: true,
       port: parsed.port,
       hostname: parsed.hostname,
-      pathname: parsed.pathname
+      pathname: parsed.pathname,
+      search: parsed.search
     })
   }`
 }

--- a/test/cache.js
+++ b/test/cache.js
@@ -206,7 +206,7 @@ test('put method', (t) => {
       data,
       cacheOpts
     ) {
-      const expectedCacheKey = `make-fetch-happen:request-cache:${HOST}/put-test`
+      const expectedCacheKey = `make-fetch-happen:request-cache:${HOST}/put-test?a=1`
       t.equal(
         cacheKey,
         expectedCacheKey,
@@ -217,7 +217,7 @@ test('put method', (t) => {
     MockCacache.prototype.put.stream = function putStream () {}
     const Cache = mockRequire({ cacache: new MockCacache() })
     const cache = new Cache(dir, {})
-    const req = new Request(`${HOST}/put-test`)
+    const req = new Request(`${HOST}/put-test?a=1`)
     const body = new Minipass()
     body.end(CONTENT)
     const resOpts = {


### PR DESCRIPTION
Include the URL's query string in the cache key. Not including the query component in the cache key can result in an ineffective cache or subtle bugs. The cache key for URLs that do not have a query component have not changed.

[RFC 7234](https://tools.ietf.org/html/rfc7234#section-2) states that "the primary cache key consists of the request method and target URI", the [query component](https://tools.ietf.org/html/rfc3986#section-3.4) being part of this.

Fixes #7 
