### PR TITLE
Skip integrity checks against error responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,6 +256,9 @@ function conditionalFetch (req, cachedRes, opts) {
 }
 
 function remoteFetchHandleIntegrity (res, integrity) {
+  if (res.status !== 200) {
+    return res // Error responses aren't subject to integrity checks.
+  }
   const oldBod = res.body
   const newBod = ssri.integrityStream({
     integrity

--- a/test/integrity.js
+++ b/test/integrity.js
@@ -141,3 +141,17 @@ test('basic integrity verification with gzip content', t => {
     t.deepEqual(buf, CONTENT_GZ, 'good content passed scrutiny 👍🏼')
   })
 })
+
+test('skip integrity check for error reponses', t => {
+  const srv = tnock(t, HOST)
+  srv.get('/wowforbidden').reply(403, Buffer.from('Forbidden'))
+  const safetch = fetch.defaults({
+    integrity: INTEGRITY
+  })
+  return safetch(`${HOST}/wowforbidden`).then(res => {
+    t.equal(res.status, 403)
+    return res.buffer() // attempt to consume body
+  }).catch(err => {
+    t.fail(`Unexpected error: ${err}`)
+  })
+})


### PR DESCRIPTION
Users report weird integrity check failures using npm 7.

These appear to be caused by early integrity checks misapplied to error responses.

This patch skips integrity checks for all responses other than 200s.

(Actually handling the error is the caller's responsibility.)

## References
https://github.com/npm/cli/issues/1800