### PR TITLE
pass tls related options to fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,6 +285,10 @@ function remoteFetch (uri, opts) {
     size: opts.size,
     counter: opts.counter,
     timeout: opts.timeout,
+    ca: opts.ca,
+    cert: opts.cert,
+    key: opts.key,
+    rejectUnauthorized: opts.strictSSL,
   }
 
   return retry(

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -952,5 +952,43 @@ test('delete cache', (t) => {
   t.end()
 })
 
+test('pass opts to fetch.Request as well as agent', t => {
+  const agent = { this_is_the_agent: true }
+  const ca = 'ca'
+  const timeout = 'timeout'
+  const cert = 'cert'
+  const key = 'key'
+  const rejectUnauthorized = 'rejectUnauthorized'
+
+  let req = null
+  const fetch = requireInject('../index.js', {
+    'minipass-fetch': Object.assign(async request => {
+      t.equal(request, req, 'got the request object')
+      t.end()
+      return {
+        headers: new Map(),
+        status: 200,
+        method: 'GET'
+      }
+    }, require('minipass-fetch'), {
+      Request: class Request{ constructor (uri, reqOpts) {
+        req = this
+        t.equal(uri, 'uri')
+        t.match(reqOpts, { agent, ca, timeout, cert, key, rejectUnauthorized })
+      }},
+    }),
+    '../agent.js': (uri, opts) => agent,
+  })
+
+  fetch('uri', {
+    agent,
+    ca,
+    timeout,
+    cert,
+    key,
+    strictSSL: rejectUnauthorized,
+  })
+})
+
 // test('retries non-POST requests on ECONNRESET')
 // test('supports automatic agent pooling on unique configs')


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
previously, the tls related options here were being passed to `https-proxy-agent` but _not_ to the requests themselves, that means when a proxy is in use we were setting the connection options for client -> proxy, but not for proxy -> internet.

this change ensures that the more common tls options are passed through to each request appropriately and allow requests to work end to end.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Related to https://github.com/npm/cli/issues/1700
