### PR TITLE
Fixed agent.js to be aware of url-encoded username and password

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -150,8 +150,8 @@ function getProxyUri (uri, opts) {
 }
 
 const getAuth = u =>
-  u.username && u.password ? `${u.username}:${u.password}`
-  : u.username ? u.username
+  u.username && u.password ? decodeURIComponent(`${u.username}:${u.password}`)
+  : u.username ? decodeURIComponent(u.username)
   : null
 
 const getPath = u => u.pathname + u.search + u.hash

--- a/test/agent.js
+++ b/test/agent.js
@@ -282,6 +282,70 @@ test('get proxy agent', async t => {
     __type: 'socks-proxy',
   }, 'socks proxy url, for http request')
 
+  t.strictSame(getProxy(new url.URL('http://user:pass@proxy.local:443/'), OPTS, false), {
+    host: 'proxy.local',
+    port: '443',
+    protocol: 'http:',
+    path: '/',
+    auth: 'user:pass',
+    ca: 'ca',
+    cert: 'cert',
+    key: undefined,
+    timeout: 2,
+    localAddress: 'local address',
+    maxSockets: 3,
+    rejectUnauthorized: true,
+    __type: 'http-proxy',
+  }, 'http proxy url, for http request')
+
+  t.strictSame(getProxy(new url.URL('http://user@proxy.local:443/'), OPTS, false), {
+    host: 'proxy.local',
+    port: '443',
+    protocol: 'http:',
+    path: '/',
+    auth: 'user',
+    ca: 'ca',
+    cert: 'cert',
+    key: undefined,
+    timeout: 2,
+    localAddress: 'local address',
+    maxSockets: 3,
+    rejectUnauthorized: true,
+    __type: 'http-proxy',
+  }, 'http proxy url, for http request')
+
+  t.strictSame(getProxy(new url.URL('http://user%231:pass@proxy.local:443/'), OPTS, false), {
+    host: 'proxy.local',
+    port: '443',
+    protocol: 'http:',
+    path: '/',
+    auth: 'user#1:pass',
+    ca: 'ca',
+    cert: 'cert',
+    key: undefined,
+    timeout: 2,
+    localAddress: 'local address',
+    maxSockets: 3,
+    rejectUnauthorized: true,
+    __type: 'http-proxy',
+  }, 'http proxy url, for http request')
+
+  t.strictSame(getProxy(new url.URL('http://user%231:pass%231@proxy.local:443/'), OPTS, false), {
+    host: 'proxy.local',
+    port: '443',
+    protocol: 'http:',
+    path: '/',
+    auth: 'user#1:pass#1',
+    ca: 'ca',
+    cert: 'cert',
+    key: undefined,
+    timeout: 2,
+    localAddress: 'local address',
+    maxSockets: 3,
+    rejectUnauthorized: true,
+    __type: 'http-proxy',
+  }, 'http proxy url, for http request')
+
   t.throws(() => getProxy(new url.URL('gopher://proxy.local'), OPTS, false), {
     message: 'unsupported proxy protocol: \'gopher:\'',
     url: 'gopher://proxy.local',


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
As described in #46 the module is currently unaware of url-encoded characters in the proxy authorization. This PR fixes this issue.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes #46
