### PR TITLE
fix: force negotiator to preload all modules

### DIFF
--- a/lib/cache/policy.js
+++ b/lib/cache/policy.js
@@ -2,6 +2,19 @@ const CacheSemantics = require('http-cache-semantics')
 const Negotiator = require('negotiator')
 const ssri = require('ssri')
 
+// HACK: negotiator lazy loads several of its own modules
+// as a micro optimization. we need to be sure that they're
+// in memory as soon as possible at startup so that we do
+// not try to lazy load them after the directory has been
+// retired during a self update of the npm CLI, we do this
+// by calling all of the methods that trigger a lazy load
+// on a fake instance.
+const preloadNegotiator = new Negotiator({ headers: {} })
+preloadNegotiator.charsets()
+preloadNegotiator.encodings()
+preloadNegotiator.languages()
+preloadNegotiator.mediaTypes()
+
 // options passed to http-cache-semantics constructor
 const policyOptions = {
   shared: false,

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { basename, join } = require('path')
+const { basename, join, sep } = require('path')
 const cacache = require('cacache')
 const fs = require('fs')
 const nock = require('nock')
@@ -36,7 +36,7 @@ t.beforeEach(() => nock.cleanAll())
 t.test('policy preload', async (t) => {
   // see comments at the top of lib/cache/policy.js
   const loadedModules = Object.keys(require.cache)
-    .filter(key => key.includes('/negotiator/') && !key.endsWith('index.js'))
+    .filter(key => key.includes(`${sep}negotiator${sep}`) && !key.endsWith('index.js'))
     .map(key => basename(key, '.js'))
 
   t.ok(loadedModules.includes('charset'), 'preloaded charset.js')

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { join } = require('path')
+const { basename, join } = require('path')
 const cacache = require('cacache')
 const fs = require('fs')
 const nock = require('nock')
@@ -32,6 +32,18 @@ const getHeaders = (content) => ({
 
 nock.disableNetConnect()
 t.beforeEach(() => nock.cleanAll())
+
+t.test('policy preload', async (t) => {
+  // see comments at the top of lib/cache/policy.js
+  const loadedModules = Object.keys(require.cache)
+    .filter(key => key.includes('/negotiator/') && !key.endsWith('index.js'))
+    .map(key => basename(key, '.js'))
+
+  t.ok(loadedModules.includes('charset'), 'preloaded charset.js')
+  t.ok(loadedModules.includes('encoding'), 'preloaded encoding.js')
+  t.ok(loadedModules.includes('language'), 'preloaded language.js')
+  t.ok(loadedModules.includes('mediaType'), 'preloaded mediaType.js')
+})
 
 t.test('storable()', async (t) => {
   const storeOpts = configureOptions({ cachePath: './foo' })


### PR DESCRIPTION
when the npm CLI self updates itself, it retires its own directory
before attempting to extract the new archive. negotiator happens to
use lazy loading and only requires its modules when they're needed
so we have to call methods that trigger the lazy loading as soon as
we can to make sure they're in memory before the npm CLI retires
its own directory

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
