### PR TITLE
fix: implement cache modes correctly

### DIFF
--- a/lib/cache/entry.js
+++ b/lib/cache/entry.js
@@ -145,6 +145,12 @@ class CacheEntry {
       return
     }
 
+    // a cache mode of 'reload' means to behave as though we have no cache
+    // on the way to the network. return undefined to allow cacheFetch to
+    // create a brand new request no matter what.
+    if (options.cache === 'reload')
+      return
+
     // find the specific entry that satisfies the request
     let match
     for (const entry of matches) {

--- a/test/integrity.js
+++ b/test/integrity.js
@@ -138,7 +138,7 @@ t.test('checks integrity on cache fetch too', async (t) => {
   const safetch = fetch.defaults({
     cacheManager: CACHE,
     integrity: INTEGRITY,
-    cache: 'reload',
+    cache: 'no-cache',
   })
 
   const goodRes = await safetch(`${HOST}/test`)


### PR DESCRIPTION
these changes align our cache modes with the whatwg fetch spec.
previously, 'reload' was behaving how 'no-cache' is meant to and
'no-cache' wasn't implemented at all

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
related to npm/cli#3424