### PR TITLE
fix: retry ERR_SOCKET_TIMEOUT from agentkeepalive

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -14,6 +14,7 @@ const RETRY_ERRORS = [
   'ECONNREFUSED', // remote host refused to open connection
   'EADDRINUSE', // failed to bind to a local port (proxy?)
   'ETIMEDOUT', // someone in the transaction is WAY TOO SLOW
+  'ERR_SOCKET_TIMEOUT', // same as above, but this one comes from agentkeepalive
   // Known codes we do NOT retry on:
   // ENOTFOUND (getaddrinfo failure. Either bad hostname, or offline)
 ]


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this is the equivalent of an ETIMEDOUT from node core, but is the error code that agentkeepalive surfaces when it destroys a socket due to an idle timeout. this is definitely something we should retry.
