### PR TITLE
fix: store a timestamp in the metadata instead of relying on the entry

### DIFF
--- a/lib/cache/entry.js
+++ b/lib/cache/entry.js
@@ -48,6 +48,7 @@ const KEEP_RESPONSE_HEADERS = [
 // return an object containing all metadata to be written to the index
 const getMetadata = (request, response, options) => {
   const metadata = {
+    time: Date.now(),
     url: request.url,
     reqHeaders: {},
     resHeaders: {},
@@ -112,9 +113,18 @@ const _policy = Symbol('policy')
 
 class CacheEntry {
   constructor ({ entry, request, response, options }) {
-    this.entry = entry
+    if (entry) {
+      this.key = entry.key
+      this.entry = entry
+      // previous versions of this module didn't write an explicit timestamp in
+      // the metadata, so fall back to the entry's timestamp. we can't use the
+      // entry timestamp to determine staleness because cacache will update it
+      // when it verifies its data
+      this.entry.metadata.time = this.entry.metadata.time || this.entry.time
+    } else
+      this.key = cacheKey(request)
+
     this.options = options
-    this.key = entry ? entry.key : cacheKey(request)
 
     // these properties are behind getters that lazily evaluate
     this[_request] = request
@@ -368,7 +378,7 @@ class CacheEntry {
     response.headers.set('x-local-cache-key', encodeURIComponent(this.key))
     response.headers.set('x-local-cache-mode', shouldBuffer ? 'buffer' : 'stream')
     response.headers.set('x-local-cache-status', status)
-    response.headers.set('x-local-cache-time', new Date(this.entry.time).toUTCString())
+    response.headers.set('x-local-cache-time', new Date(this.entry.metadata.time).toUTCString())
     return response
   }
 

--- a/lib/cache/policy.js
+++ b/lib/cache/policy.js
@@ -67,7 +67,7 @@ class CachePolicy {
       // this is necessary because the CacheSemantics constructor forces
       // the value to Date.now() which means a policy created from a
       // cache entry is likely to always identify itself as stale
-      this.policy._responseTime = this.entry.time
+      this.policy._responseTime = this.entry.metadata.time
     }
   }
 


### PR DESCRIPTION
this is to avoid cacache.verify() overwriting the entry's timestamp and causing make-fetch-happen to believe every index is fresh

closes #55