### PR TITLE
fix: use the same strictSSL default as tls.connect

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -33,7 +33,7 @@ function getAgent (uri, opts) {
       ? `proxy:${pxuri.protocol}//${pxuri.host}:${pxuri.port}`
       : '>no-proxy<',
     `local-address:${opts.localAddress || '>no-local-address<'}`,
-    `strict-ssl:${isHttps ? !!opts.strictSSL : '>no-strict-ssl<'}`,
+    `strict-ssl:${isHttps ? opts.rejectUnauthorized : '>no-strict-ssl<'}`,
     `ca:${(isHttps && opts.ca) || '>no-ca<'}`,
     `cert:${(isHttps && opts.cert) || '>no-cert<'}`,
     `key:${(isHttps && opts.key) || '>no-key<'}`,
@@ -72,7 +72,7 @@ function getAgent (uri, opts) {
     cert: opts.cert,
     key: opts.key,
     localAddress: opts.localAddress,
-    rejectUnauthorized: opts.strictSSL,
+    rejectUnauthorized: opts.rejectUnauthorized,
     timeout: agentTimeout,
   }) : new HttpAgent({
     maxSockets: agentMaxSockets,
@@ -173,7 +173,7 @@ function getProxy (proxyUrl, opts, isHttps) {
     timeout: getAgentTimeout(opts.timeout),
     localAddress: opts.localAddress,
     maxSockets: getMaxSockets(opts.maxSockets),
-    rejectUnauthorized: opts.strictSSL,
+    rejectUnauthorized: opts.rejectUnauthorized,
   }
 
   if (proxyUrl.protocol === 'http:' || proxyUrl.protocol === 'https:') {

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,10 +7,9 @@ const conditionalHeaders = [
 ]
 
 const configureOptions = (opts) => {
-  const options = { ...opts }
+  const {strictSSL, ...options} = { ...opts }
   options.method = options.method ? options.method.toUpperCase() : 'GET'
-  if (Object.prototype.hasOwnProperty.call(options, 'strictSSL'))
-    options.rejectUnauthorized = options.strictSSL
+  options.rejectUnauthorized = strictSSL !== false
 
   if (!options.retry)
     options.retry = { retries: 0 }

--- a/test/agent.js
+++ b/test/agent.js
@@ -39,7 +39,7 @@ const OPTS = {
   cert: 'cert',
   key: 'key',
   localAddress: 'localAddress',
-  strictSSL: 'strictSSL',
+  rejectUnauthorized: 'strictSSL',
   timeout: 5,
 }
 
@@ -183,7 +183,7 @@ test('get proxy agent', async t => {
     timeout: 1,
     localAddress: 'local address',
     maxSockets: 3,
-    strictSSL: true,
+    rejectUnauthorized: true,
   }
 
   t.strictSame(getProxy(new url.URL('http://proxy.local:443/'), OPTS, true), {

--- a/test/lambda-agent.js
+++ b/test/lambda-agent.js
@@ -29,7 +29,7 @@ const OPTS = {
   cert: 'cert',
   key: 'key',
   localAddress: 'localAddress',
-  strictSSL: 'strictSSL',
+  rejectUnauthorized: 'strictSSL',
   timeout: 5,
 }
 

--- a/test/options.js
+++ b/test/options.js
@@ -6,66 +6,75 @@ const { test } = require('tap')
 test('configure options', async (t) => {
   test('supplied with no value', async (t) => {
     const opts = configureOptions()
-    const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default' }
+    const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: true }
     t.same(opts, expectedObject, 'should return default opts')
   })
 
   test('supplied with empty object', async (t) => {
     const opts = configureOptions({})
-    const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default' }
+    const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: true }
     t.same(opts, expectedObject, 'should return default opts')
   })
 
   test('changes method to upper case', async (t) => {
     const actualOpts = { method: 'post' }
     const opts = configureOptions(actualOpts)
-    const expectedObject = { method: 'POST', retry: { retries: 0 }, cache: 'default' }
+    const expectedObject = { method: 'POST', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: true }
     t.same(opts, expectedObject, 'should return upper cased method')
   })
 
   test('copies strictSSL to rejectUnauthorized', async (t) => {
     const trueOpts = configureOptions({ strictSSL: true })
-    const trueExpectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', strictSSL: true, rejectUnauthorized: true }
+    const trueExpectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: true }
     t.same(trueOpts, trueExpectedObject, 'should return default opts and copy strictSSL')
 
     const falseOpts = configureOptions({ strictSSL: false })
-    const falseExpectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', strictSSL: false, rejectUnauthorized: false }
+    const falseExpectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: false }
     t.same(falseOpts, falseExpectedObject, 'should return default opts and copy strictSSL')
+
+    const undefinedOpts = configureOptions({ strictSSL: undefined })
+    t.same(undefinedOpts, trueExpectedObject, 'should treat strictSSL: undefined as true just like tls.connect')
+
+    const unsetOpts = configureOptions({ })
+    t.same(unsetOpts, trueExpectedObject, 'should treat unset strictSSL as true just like tls.connect')
+
+    const nullOpts = configureOptions({ strictSSL: null })
+    t.same(nullOpts, trueExpectedObject, 'should treat strictSSL: null as true just like tls.connect')
   })
 
   test('should set retry property correctly', async (t) => {
     t.test('no property given', async (t) => {
       const actualOpts = { method: 'GET' }
       const opts = configureOptions(actualOpts)
-      const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default' }
+      const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: true }
       t.same(opts, expectedObject, 'should return default retry property')
     })
 
     t.test('invalid property give', async (t) => {
       const actualOpts = { method: 'GET', retry: 'one' }
       const opts = configureOptions(actualOpts)
-      const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default' }
+      const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: true }
       t.same(opts, expectedObject, 'should return default retry property')
     })
 
     t.test('number value for retry given', async (t) => {
       const actualOpts = { method: 'GET', retry: 10 }
       const opts = configureOptions(actualOpts)
-      const expectedObject = { method: 'GET', retry: { retries: 10 }, cache: 'default' }
+      const expectedObject = { method: 'GET', retry: { retries: 10 }, cache: 'default', rejectUnauthorized: true }
       t.same(opts, expectedObject, 'should set retry value, if number')
     })
 
     t.test('string number value for retry given', async (t) => {
       const actualOpts = { method: 'GET', retry: '10' }
       const opts = configureOptions(actualOpts)
-      const expectedObject = { method: 'GET', retry: { retries: 10 }, cache: 'default' }
+      const expectedObject = { method: 'GET', retry: { retries: 10 }, cache: 'default', rejectUnauthorized: true }
       t.same(opts, expectedObject, 'should set retry value')
     })
 
     t.test('truthy value for retry given', async (t) => {
       const actualOpts = { method: 'GET', retry: {} }
       const opts = configureOptions(actualOpts)
-      const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default' }
+      const expectedObject = { method: 'GET', retry: { retries: 0 }, cache: 'default', rejectUnauthorized: true }
       t.same(opts, expectedObject, 'should return default retry property')
     })
   })
@@ -76,6 +85,7 @@ test('configure options', async (t) => {
       const opts = configureOptions(actualOpts)
       const expectedObject = {
         method: 'GET',
+        rejectUnauthorized: true,
         retry: { retries: 0 },
         cache: 'default',
       }
@@ -87,6 +97,7 @@ test('configure options', async (t) => {
       const opts = configureOptions(actualOpts)
       const expectedObject = {
         method: 'GET',
+        rejectUnauthorized: true,
         retry: { retries: 0 },
         cache: 'something',
       }
@@ -98,6 +109,7 @@ test('configure options', async (t) => {
       const opts = configureOptions(actualOpts)
       const expectedObject = {
         method: 'GET',
+        rejectUnauthorized: true,
         retry: { retries: 0 },
         cache: 'default',
         cachePath: './foo',
@@ -110,6 +122,7 @@ test('configure options', async (t) => {
       const opts = configureOptions(actualOpts)
       const expectedObject = {
         method: 'GET',
+        rejectUnauthorized: true,
         retry: { retries: 0 },
         cache: 'default',
         cachePath: './foo',
@@ -123,6 +136,7 @@ test('configure options', async (t) => {
       const opts = configureOptions(actualOpts)
       const expectedObject = {
         method: 'GET',
+        rejectUnauthorized: true,
         retry: { retries: 0 },
         cache: 'no-store',
       }


### PR DESCRIPTION
when calculating the agent cache key, use the same coercion of the strictSSL option to default as tls.connect’s rejectUnauthorized so that we don’t use a cached agent that is inconsistent with the behavior when creating a new agent.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

I was reading the source to find the default behavior of `strictSSL` and I discovered that `tls.connect` uses the value `rejectUnauthorized !== false`, but `getAgent` creates a cache key containing `!!strictSSL` instead. That means that if you call `fetch('https://example.com/', {strictSSL: false})` followed by `fetch('https://example.com/', {})`, the second call would not verify the TLS certificate even though it should!

Also, `configureOptions` was setting `options.rejectUnauthorized`, but this wasn’t used by `getAgent`.

This commit coerces `useSSL` to boolean one time, within `configureOptions`, and does so in the same way as `rejectUnauthorized` is coerced by `tls.connect` (i.e., `strictSSL !== false`).

(note: minipass-fetch also does some coercion of `rejectUnauthorized`, but this is unused ([request.js](https://github.com/npm/minipass-fetch/blob/v1.3.4/lib/request.js#L85))) 

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

* `https.Agent` constructor passes `options` to `super(options)` ([https.js](https://github.com/nodejs/node/blob/v16.7.0/lib/https.js#L180))
* `http.Agent` saves `options` to `this.options` ([_http_agent.js](https://github.com/nodejs/node/blob/v16.7.0/lib/_http_agent.js#L102))
* `http.Agent.prototype.addRequest` ([_https_agent.js](https://github.com/nodejs/node/blob/v16.7.0/lib/_http_agent.js#L292)) passes the options to `createSocket`, which passes them to `this.createConnection`
*  `https.Agent.prototype.createConnection` ([https.js](https://github.com/nodejs/node/blob/v16.7.0/lib/https.js#L143)) passes the options to `tls.connect` ([tls.js](https://github.com/nodejs/node/blob/v16.7.0/lib/tls.js#L306) re-exports from [tls_wrap.js](https://github.com/nodejs/node/blob/v16.7.0/lib/_tls_wrap.js#L1629)), which coerces using `options.rejectUnauthorized !== false`
