### PR TITLE
replace minipass pipeline with simple pipe

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,5 +1,4 @@
 const Minipass = require('minipass')
-const MinipassPipeline = require('minipass-pipeline')
 const fetch = require('minipass-fetch')
 const promiseRetry = require('promise-retry')
 const ssri = require('ssri')
@@ -51,7 +50,11 @@ const remoteFetch = (request, options) => {
         // we got a 200 response and the user has specified an expected
         // integrity value, so wrap the response in an ssri stream to verify it
         const integrityStream = ssri.integrityStream({ integrity: _opts.integrity })
-        res = new fetch.Response(new MinipassPipeline(res.body, integrityStream), res)
+
+        res.body.pipe(integrityStream)
+        res.body.on('error', err => integrityStream.emit('error', err))
+
+        res = new fetch.Response(integrityStream, res)
       }
 
       res.headers.set('x-fetch-attempts', attemptNum)


### PR DESCRIPTION
I can reliably cause tar integrity errors while downloading packages
from npm thru an http proxy that uses chunked encoding. The error seems
to be in make-fetch-happen, minipass-fetch or one of the minipass
libraries. I don't understand the root cause but I'm unable to reproduce
the issue after applying this patch.

My guess is that something in the stack expects res.body to be a
Minipass instance but not MinipassPipeline, or creating the pipeline
starts body flowing before all listeners are connected, missing some
chunks of data.

fixes npm/cli#3884

To reproduce

1. Start the [chunked-encoding proxy](https://github.com/everett1992/make-fetch-happen/blob/chunked-encoding/proxy.js)
2. In a new terminal create a npm project
   `mkdir chunked-encoding-error && cd chunked-encoding-error && echo '{}' > package.json`
3. configure npm to use the registry
   `npm config --location project set registry http://localhost:4000`
4. remove npm cache.
5. install any package from the registry (this should fail).
   - I recommend a package without dependencies, like lodash or typescript, debugging is easier.
   - The error isn't 100% consistent, you may want to run this step in
     a loop
     ```
     while rm ~/.npm/_cacache node_modules package-lock.json -rf && npm install --no-save lodash; do; done
     ```

[chunked-encoding proxy]: https://github.com/everett1992/make-fetch-happen/blob/chunked-encoding/proxy.js
