### PR TITLE
feat(cache): added ability to control which response headers are stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pooling, proxies, retries, [and more](#features)!
   * [`make-fetch-happen` options](#extra-options)
     * [`opts.cachePath`](#opts-cache-path)
     * [`opts.cache`](#opts-cache)
+    * [`opts.cachedResponseHeaders`](#opts-cache-response-headers)
     * [`opts.proxy`](#opts-proxy)
     * [`opts.noProxy`](#opts-no-proxy)
     * [`opts.ca, opts.cert, opts.key`](#https-opts)
@@ -138,6 +139,7 @@ make-fetch-happen augments the `minipass-fetch` API with additional features ava
 
 * [`opts.cachePath`](#opts-cache-path) - Cache target to read/write
 * [`opts.cache`](#opts-cache) - `fetch` cache mode. Controls cache *behavior*.
+* [`opts.cachedResponseHeaders`](#opts-cache-response-headers) - response headers stored in cache
 * [`opts.proxy`](#opts-proxy) - Proxy agent
 * [`opts.noProxy`](#opts-no-proxy) - Domain segments to disable proxying for.
 * [`opts.ca, opts.cert, opts.key, opts.strictSSL`](#https-opts)
@@ -254,6 +256,19 @@ fetch('https://registry.npmjs.org/make-fetch-happen', {
 fetch('https://registry.npmjs.org/make-fetch-happen', {
   cache: 'force-cache'
 })
+```
+
+#### <a name="opts-cache-response-headers"></a> `> opts.cacheResponseHeaders`
+
+A list of HTTP response headers to store within the cache and to include in cached
+responses. The default list of stored cached response headers can be obtained
+via `fetch.CACHED_RESPONSE_HEADERS`
+
+```javascript
+fetch('https://registry.npmjs.org/make-fetch-happen', {
+  cachePath: './my-local-cache'
+  cachedResponseHeaders: ['link', ...fetch.CACHED_RESPONSE_HEADERS]
+}) // -> 200-level response will be written to disk
 ```
 
 #### <a name="opts-proxy"></a> `> opts.proxy`

--- a/lib/cache/cached-response-headers.js
+++ b/lib/cache/cached-response-headers.js
@@ -1,0 +1,20 @@
+
+// allow list for response headers that will be written to the cache index
+// note: we must not store the real response's age header, or when we load
+// a cache policy based on the metadata it will think the cached response
+// is always stale
+const CACHED_RESPONSE_HEADERS = [
+  'cache-control',
+  'content-encoding',
+  'content-language',
+  'content-type',
+  'date',
+  'etag',
+  'expires',
+  'last-modified',
+  'location',
+  'pragma',
+  'vary',
+]
+
+module.exports = CACHED_RESPONSE_HEADERS

--- a/lib/cache/entry.js
+++ b/lib/cache/entry.js
@@ -9,6 +9,7 @@ const url = require('url')
 const CachePolicy = require('./policy.js')
 const cacheKey = require('./key.js')
 const remote = require('../remote.js')
+const CACHED_RESPONSE_HEADERS = require('./cached-response-headers.js')
 
 const hasOwnProperty = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 
@@ -25,24 +26,6 @@ const KEEP_REQUEST_HEADERS = [
   'accept-language',
   'accept',
   'cache-control',
-]
-
-// allow list for response headers that will be written to the cache index
-// note: we must not store the real response's age header, or when we load
-// a cache policy based on the metadata it will think the cached response
-// is always stale
-const KEEP_RESPONSE_HEADERS = [
-  'cache-control',
-  'content-encoding',
-  'content-language',
-  'content-type',
-  'date',
-  'etag',
-  'expires',
-  'last-modified',
-  'location',
-  'pragma',
-  'vary',
 ]
 
 // return an object containing all metadata to be written to the index
@@ -89,7 +72,7 @@ const getMetadata = (request, response, options) => {
     }
   }
 
-  for (const name of KEEP_RESPONSE_HEADERS) {
+  for (const name of options.cachedResponseHeaders || CACHED_RESPONSE_HEADERS) {
     if (response.headers.has(name))
       metadata.resHeaders[name] = response.headers.get(name)
   }
@@ -428,7 +411,7 @@ class CacheEntry {
       // since they do not include a body, so we copy values for headers that were
       // in the old cache entry to the new one, if the new metadata does not already
       // include that header
-      for (const name of KEEP_RESPONSE_HEADERS) {
+      for (const name of options.cachedResponseHeaders || CACHED_RESPONSE_HEADERS) {
         if (!hasOwnProperty(metadata.resHeaders, name) && hasOwnProperty(this.entry.metadata.resHeaders, name))
           metadata.resHeaders[name] = this.entry.metadata.resHeaders[name]
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const { FetchError, Headers, Request, Response } = require('minipass-fetch')
 
 const configureOptions = require('./options.js')
 const fetch = require('./fetch.js')
+const CACHED_RESPONSE_HEADERS = require('./cache/cached-response-headers.js')
 
 const makeFetchHappen = (url, opts) => {
   const options = configureOptions(opts)
@@ -38,3 +39,4 @@ module.exports.FetchError = FetchError
 module.exports.Headers = Headers
 module.exports.Request = Request
 module.exports.Response = Response
+module.exports.CACHED_RESPONSE_HEADERS = CACHED_RESPONSE_HEADERS


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
## What

Provides the `cachedResponseHeaders` configuration option, which can be used to adjust which HTTP response headers are stored in the cached and then populated in cached responses.

If the `cachedResponseHeaders` option is not provided, then a default set of headers are stored as per the existing behaviour, maintaining backwards compatibility.

To allow users to store headers in addition to the default set of headers, the default set of headers is available from `mfh.CACHED_RESPONSE_HEADERS`

## Why

Some HTTP servers provide important response headers to clients that are not included in the set of headers that are stored in the cache, such as the [HTTP Link header](https://datatracker.ietf.org/doc/html/rfc8288). Failure to include these headers in cached responses can break the clients that expect and use these headers.

## References
Related to #62

