### PR TITLE
fix: strip cookie header on redirect across hostnames

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -56,8 +56,10 @@ const getRedirect = (request, response, options) => {
   // Remove authorization if changing hostnames (but not if just
   // changing ports or protocols).  This matches the behavior of request:
   // https://github.com/request/request/blob/b12a6245/lib/redirect.js#L134-L138
-  if (new url.URL(request.url).hostname !== redirectUrl.hostname)
+  if (new url.URL(request.url).hostname !== redirectUrl.hostname) {
     request.headers.delete('authorization')
+    request.headers.delete('cookie')
+  }
 
   // for POST request with 301/302 response, or any request with 303 response,
   // use GET when following redirect


### PR DESCRIPTION
Fixes https://github.com/npm/make-fetch-happen/issues/70
