### PR TITLE
update deps, roll back lazy load hack'

### DIFF
--- a/lib/cache/policy.js
+++ b/lib/cache/policy.js
@@ -2,19 +2,6 @@ const CacheSemantics = require('http-cache-semantics')
 const Negotiator = require('negotiator')
 const ssri = require('ssri')
 
-// HACK: negotiator lazy loads several of its own modules
-// as a micro optimization. we need to be sure that they're
-// in memory as soon as possible at startup so that we do
-// not try to lazy load them after the directory has been
-// retired during a self update of the npm CLI, we do this
-// by calling all of the methods that trigger a lazy load
-// on a fake instance.
-const preloadNegotiator = new Negotiator({ headers: {} })
-preloadNegotiator.charsets()
-preloadNegotiator.encodings()
-preloadNegotiator.languages()
-preloadNegotiator.mediaTypes()
-
 // options passed to http-cache-semantics constructor
 const policyOptions = {
   shared: false,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^8.7.0",
     "mkdirp": "^1.0.4",
     "nock": "^13.0.11",
-    "npmlog": "^5.0.0",
+    "npmlog": "^6.0.0",
     "require-inject": "^1.4.2",
     "rimraf": "^3.0.2",
     "safe-buffer": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "agentkeepalive": "^4.1.3",
     "cacache": "^15.2.0",
     "http-cache-semantics": "^4.1.0",
-    "http-proxy-agent": "^4.0.1",
+    "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "is-lambda": "^1.0.1",
     "lru-cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "minipass-fetch": "^1.3.2",
     "minipass-flush": "^1.0.5",
     "minipass-pipeline": "^1.2.4",
-    "negotiator": "^0.6.2",
+    "negotiator": "^0.6.3",
     "promise-retry": "^2.0.1",
     "socks-proxy-agent": "^6.0.0",
     "ssri": "^8.0.0"

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { basename, join, sep } = require('path')
+const { join } = require('path')
 const { Readable } = require('stream')
 const cacache = require('cacache')
 const fs = require('fs')
@@ -33,18 +33,6 @@ const getHeaders = (content) => ({
 
 nock.disableNetConnect()
 t.beforeEach(() => nock.cleanAll())
-
-t.test('policy preload', async (t) => {
-  // see comments at the top of lib/cache/policy.js
-  const loadedModules = Object.keys(require.cache)
-    .filter(key => key.includes(`${sep}negotiator${sep}`) && !key.endsWith('index.js'))
-    .map(key => basename(key, '.js'))
-
-  t.ok(loadedModules.includes('charset'), 'preloaded charset.js')
-  t.ok(loadedModules.includes('encoding'), 'preloaded encoding.js')
-  t.ok(loadedModules.includes('language'), 'preloaded language.js')
-  t.ok(loadedModules.includes('mediaType'), 'preloaded mediaType.js')
-})
 
 t.test('storable()', async (t) => {
   const storeOpts = configureOptions({ cachePath: './foo' })


### PR DESCRIPTION
- deps: negotiator@0.6.3
- fix: revert negotiator preload hack
- deps: npmlog@6.0.0
- deps: http-proxy-agent@5.0.0
