### PR TITLE
fix: set agentkeepalive freeSocketTimeout back to 15 seconds

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -76,10 +76,12 @@ function getAgent (uri, opts) {
     localAddress: opts.localAddress,
     rejectUnauthorized: opts.rejectUnauthorized,
     timeout: agentTimeout,
+    freeSocketTimeout: 15000,
   }) : new HttpAgent({
     maxSockets: agentMaxSockets,
     localAddress: opts.localAddress,
     timeout: agentTimeout,
+    freeSocketTimeout: 15000,
   })
   AGENT_CACHE.set(key, agent)
   return agent

--- a/test/agent.js
+++ b/test/agent.js
@@ -52,6 +52,7 @@ t.test('all expected options passed down to HttpAgent', async t => {
     maxSockets: 5,
     localAddress: 'localAddress',
     timeout: 6,
+    freeSocketTimeout: 15000,
   }, 'only expected options passed to HttpAgent')
 })
 
@@ -61,6 +62,7 @@ t.test('timeout 0 keeps timeout 0', async t => {
     maxSockets: 5,
     localAddress: 'localAddress',
     timeout: 0,
+    freeSocketTimeout: 15000,
   }, 'only expected options passed to HttpAgent')
 })
 
@@ -70,6 +72,7 @@ t.test('no max sockets gets 15 max sockets', async t => {
     maxSockets: 15,
     localAddress: 'localAddress',
     timeout: 6,
+    freeSocketTimeout: 15000,
   }, 'only expected options passed to HttpAgent')
 })
 
@@ -79,6 +82,7 @@ t.test('no timeout gets timeout 0', async t => {
     maxSockets: 5,
     localAddress: 'localAddress',
     timeout: 0,
+    freeSocketTimeout: 15000,
   }, 'only expected options passed to HttpAgent')
 })
 
@@ -92,6 +96,7 @@ t.test('all expected options passed down to HttpsAgent', async t => {
     localAddress: 'localAddress',
     rejectUnauthorized: 'strictSSL',
     timeout: 6,
+    freeSocketTimeout: 15000,
   }, 'only expected options passed to HttpsAgent')
 })
 


### PR DESCRIPTION
this is a bit of a bandaid for the timeout issue that got introduced here recently. it makes our tests pass consistently again without timeouts, but it does also indicate some potential issues in minipass-fetch. or at least issues between minipass-fetch and agentkeepalive..

either way, this would be great to land to get our CI happy again and to stop causing other peoples tests to potentially fail (node-gyp saw this issue on their end as well) and we can move on to figuring out how to fix the root cause later.