### PR TITLE
fix: default verbatim to undefined

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -5,7 +5,7 @@ const defaultOptions = exports.defaultOptions = {
   family: undefined,
   hints: dns.ADDRCONFIG,
   all: false,
-  verbatim: true,
+  verbatim: undefined,
 }
 
 const lookupCache = exports.lookupCache = new LRUCache({ max: 50 })


### PR DESCRIPTION
defaulting `verbatim` to `undefined` allows both the node flag `--dns-result-order` and `dns.setDefaultResultOrder()` to be respected

closes #134
