### PR TITLE
fix: make `defaults` chaining actually work (v9 regression)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const makeFetchHappen = (url, opts) => {
   return fetch(request, options)
 }
 
-makeFetchHappen.defaults = (defaultUrl, defaultOptions = {}) => {
+makeFetchHappen.defaults = (defaultUrl, defaultOptions = {}, wrappedFetch = makeFetchHappen) => {
   if (typeof defaultUrl === 'object') {
     defaultOptions = defaultUrl
     defaultUrl = null
@@ -26,10 +26,11 @@ makeFetchHappen.defaults = (defaultUrl, defaultOptions = {}) => {
         ...options.headers,
       },
     }
-    return makeFetchHappen(finalUrl, finalOptions)
+    return wrappedFetch(finalUrl, finalOptions)
   }
 
-  defaultedFetch.defaults = makeFetchHappen.defaults
+  defaultedFetch.defaults = (defaultUrl1, defaultOptions1 = {}) =>
+    makeFetchHappen.defaults(defaultUrl1, defaultOptions1, defaultedFetch)
   return defaultedFetch
 }
 

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -21,7 +21,7 @@ t.test('can set default url', async (t) => {
 
 t.test('allows default headers', async (t) => {
   const srv = nock('http://localhost', {
-    reqHeaders: {
+    reqheaders: {
       'x-foo': 'bar',
       'x-bar': 'baz',
     },
@@ -33,6 +33,30 @@ t.test('allows default headers', async (t) => {
   const res = await defaultedFetch('http://localhost/test', {
     headers: {
       'x-bar': 'baz',
+    },
+  })
+  t.equal(res.status, 200, 'got success')
+  const buf = await res.buffer()
+  t.same(buf, Buffer.from('success'), 'got body')
+  t.ok(srv.isDone())
+})
+
+t.test('layering default headers works', async (t) => {
+  const srv = nock('http://localhost', {
+    reqheaders: {
+      'x-foo': 'bar',
+      'x-bar': 'baz',
+      'x-another': 'yep',
+    },
+  })
+    .get('/test')
+    .reply(200, 'success')
+
+  const defaultedFetch1 = fetch.defaults({ headers: { 'x-foo': 'bar' } })
+  const defaultedFetch2 = defaultedFetch1.defaults({ headers: { 'x-bar': 'baz' } })
+  const res = await defaultedFetch2('http://localhost/test', {
+    headers: {
+      'x-another': 'yep',
     },
   })
   t.equal(res.status, 200, 'got success')


### PR DESCRIPTION
The README says:

> A defaulted `fetch` will also have a `.defaults()` method, so they can
> be chained.

But this didn't really work, because while the `defaults` method was
placed on the `defaulted` fetch, a chained defaulted fetch would just
call the original fetch function directly instead of the intermediate
function.

This PR makes chaining actually work and adds a test.

Also, it fixes the previous test, which wasn't actually verifying that
the correct request headers were received because it used the nock API
incorrectly: the option is `reqheaders` not `reqHeaders`.

Note that this was a regression in v9.0.0; the [equivalent line before the refactor](https://github.com/npm/make-fetch-happen/blob/4f3384738fe02a993b0e9f94f182ea5831975bf7/index.js#L41) grabbed `this` and called that instead. (We don't use that approach here because it doesn't work in an arrow function.)