### PR TITLE
fix: respect given algorithms instead of always using sha512

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -52,7 +52,11 @@ const remoteFetch = (request, options) => {
       if (_opts.integrity && res.status === 200) {
         // we got a 200 response and the user has specified an expected
         // integrity value, so wrap the response in an ssri stream to verify it
-        const integrityStream = ssri.integrityStream({ integrity: _opts.integrity })
+        const integrityStream = ssri.integrityStream({
+          algorithms: _opts.algorithms,
+          integrity: _opts.integrity,
+          size: _opts.size,
+        })
         const pipeline = new CachingMinipassPipeline({
           events: ['integrity', 'size'],
         }, res.body, integrityStream)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
   "tap": {
     "color": 1,
     "files": "test/*.js",
-    "check-coverage": true
+    "check-coverage": true,
+    "timeout": 60
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
this corrects the issue where we write content with an expected sha1 integrity as sha512 causing us to effectively not cache it at all, now content is correctly written as sha1 and can be read from the cache appropriately
