### PR TITLE
fix: use hostname for socks agent

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -198,6 +198,9 @@ function getProxy (proxyUrl, opts, isHttps) {
       return new HttpsProxyAgent(popts)
     }
   } else if (proxyUrl.protocol.startsWith('socks')) {
+    // socks-proxy-agent uses hostname not host
+    popts.hostname = popts.host
+    delete popts.host
     return new SocksProxyAgent(popts)
   } else {
     throw Object.assign(

--- a/test/agent.js
+++ b/test/agent.js
@@ -224,7 +224,7 @@ t.test('get proxy agent', async t => {
   }, 'https proxy url, for https request')
 
   t.strictSame(getProxy(new url.URL('socks://proxy.local:443/'), PROXY_OPTS, true), {
-    host: 'proxy.local',
+    hostname: 'proxy.local',
     port: '443',
     protocol: 'socks:',
     path: '/',
@@ -272,7 +272,7 @@ t.test('get proxy agent', async t => {
   }, 'https proxy url, for http request')
 
   t.strictSame(getProxy(new url.URL('socks://proxy.local:443/'), PROXY_OPTS, false), {
-    host: 'proxy.local',
+    hostname: 'proxy.local',
     port: '443',
     protocol: 'socks:',
     path: '/',


### PR DESCRIPTION
host was deprecated and removed in the next semver major
