### PR TITLE
fix: TypeError: SocksProxyAgent is not a constructor

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -171,7 +171,7 @@ const getPath = u => u.pathname + u.search + u.hash
 
 const HttpProxyAgent = require('http-proxy-agent')
 const HttpsProxyAgent = require('https-proxy-agent')
-const SocksProxyAgent = require('socks-proxy-agent')
+const {SocksProxyAgent} = require('socks-proxy-agent')
 module.exports.getProxy = getProxy
 function getProxy (proxyUrl, opts, isHttps) {
   // our current proxy agents do not support an overridden dns lookup method, so will not

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -171,7 +171,7 @@ const getPath = u => u.pathname + u.search + u.hash
 
 const HttpProxyAgent = require('http-proxy-agent')
 const HttpsProxyAgent = require('https-proxy-agent')
-const {SocksProxyAgent} = require('socks-proxy-agent')
+const { SocksProxyAgent } = require('socks-proxy-agent')
 module.exports.getProxy = getProxy
 function getProxy (proxyUrl, opts, isHttps) {
   // our current proxy agents do not support an overridden dns lookup method, so will not

--- a/test/agent.js
+++ b/test/agent.js
@@ -9,7 +9,7 @@ const agent = t.mock('../lib/agent.js', {
   agentkeepalive: MockHttp,
   'https-proxy-agent': mockHttpAgent('https-proxy'),
   'http-proxy-agent': mockHttpAgent('http-proxy'),
-  'socks-proxy-agent': mockHttpAgent('socks-proxy'),
+  'socks-proxy-agent': { SocksProxyAgent: mockHttpAgent('socks-proxy') },
 })
 
 function mockHttpAgent (type) {


### PR DESCRIPTION
## What

### Bug: SocksProxyAgent is not a constructor

In the documentation and code of `socks-proxy-agent` 7.0.0, the `SocksProxyAgent` class is no longer exported by default.
<img width="727" alt="image" src="https://user-images.githubusercontent.com/36876080/174281053-ed57593a-bb6c-4151-bcf8-3a414264b20a.png">


So when we use the default export, the error `SocksProxyAgent is not a constructor` will be thrown
<img width="996" alt="image" src="https://user-images.githubusercontent.com/36876080/174281102-45c7e544-708a-43c1-872e-39fdba6657c7.png">