### PR TITLE
feat: Store the link header in cache

### DIFF
--- a/lib/cache/entry.js
+++ b/lib/cache/entry.js
@@ -35,6 +35,7 @@ const KEEP_RESPONSE_HEADERS = [
   'etag',
   'expires',
   'last-modified',
+  'link',
   'location',
   'pragma',
   'vary',


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR just adds the response link header to the cached information. This header contains data we could store without compromising security or affecting the cache.

I need this header because I'm caching responses from the GitHub API and without this header, I cannot paginate the responses.

I have tested it and is working and the tests are passing.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
related to #62 #64  