### PR TITLE
docs(readme): Document cause argument to onRetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,14 +321,14 @@ fetch('http://one-more.site.com', {
 
 #### <a name="opts-onretry"></a> `> opts.onRetry`
 
-A function called whenever a retry is attempted.
+A function called with the response or error which caused the retry whenever one is attempted.
 
 ##### Example
 
 ```javascript
 fetch('https://flaky.site.com', {
-  onRetry() {
-    console.log('we will retry!')
+  onRetry(cause) {
+    console.log('we will retry because of', cause)
   }
 })
 ```


### PR DESCRIPTION
`onRetry` is always called with one of the following:

1. A response from minipass-fetch

https://github.com/npm/make-fetch-happen/blob/2631db8306864f1812278d560b9bd0ca400478cd/lib/remote.js#L83

2. An error thrown by or from a rejected promise from minipass-fetch or promise-retry

https://github.com/npm/make-fetch-happen/blob/2631db8306864f1812278d560b9bd0ca400478cd/lib/remote.js#L106

This PR updates the documentation to reflect this.

I have not added an entry to the changelog as it is not requested in the contribution guide and I don't believe that this change merits one.