### PR TITLE
Update to latest cacache, because of the error:

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "ISC",
   "dependencies": {
     "agentkeepalive": "^4.2.1",
-    "cacache": "^17.0.0",
+    "cacache": "^17.0.4",
     "http-cache-semantics": "^4.1.0",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",


### PR DESCRIPTION
> @keyv/sqlite > sqlite3 > node-gyp > make-fetch-happen > cacache > @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli