### PR TITLE
fix: let fetch option respect NODE_TLS_REJECT_UNAUTHORIZED env as def…

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -9,7 +9,7 @@ const conditionalHeaders = [
 ]
 
 const configureOptions = (opts) => {
-  const { strictSSL, ...options } = { ...opts }
+  const { strictSSL = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0', ...options } = { ...opts }
   options.method = options.method ? options.method.toUpperCase() : 'GET'
   options.rejectUnauthorized = strictSSL !== false
 


### PR DESCRIPTION
node-gyp call this request by default and, strictSSL always be true. And NODE_TLS_REJECT_UNAUTHORIZED can't effect this variable.

[See this issue](https://github.com/npm/minipass-fetch/issues/61#issue-1248514878)