### PR TITLE
feat: cache 404/410 responses

### DIFF
--- a/lib/cache/entry.js
+++ b/lib/cache/entry.js
@@ -245,12 +245,12 @@ class CacheEntry {
   // wraps the response in a pipeline that stores the data
   // in the cache while the user consumes it
   async store (status) {
-    // if we got a status other than 200, 301, or 308,
+    // if we got a status other than 200, 301, 308, 404 or 410
     // or the CachePolicy forbid storage, append the
     // cache status header and return it untouched
     if (
       this.request.method !== 'GET' ||
-      ![200, 301, 308].includes(this.response.status) ||
+      ![200, 301, 308, 404, 410].includes(this.response.status) ||
       !this.policy.storable()
     ) {
       this.response.headers.set('x-local-cache-status', 'skip')


### PR DESCRIPTION
I've just been debugging the requests made by my app and spotted that 404 responses aren't cached.

The list of status codes that can be cached is rather small in comparison to the usual range (e.g. https://www.rfc-editor.org/rfc/rfc7231#section-6.1, https://developer.mozilla.org/en-US/docs/Glossary/Cacheable).

I've added `404 Not Found` and `410 Gone` to the list (rather than a full list).