### PR TITLE
deps: remove is-lambda dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@npmcli/agent": "^2.0.0",
     "cacache": "^18.0.0",
     "http-cache-semantics": "^4.1.1",
-    "is-lambda": "^1.0.1",
     "minipass": "^7.0.2",
     "minipass-fetch": "^3.0.0",
     "minipass-flush": "^1.0.5",


### PR DESCRIPTION
This dependency stopped being used in commit 7c25367, as the responsibility for the HTTP agent was moved outside this package, but the dependency was not removed from package.json.

`@npmcli/agent` doesn't use `is-lambda` either, so this does actually remove a dependency.