### PR TITLE
fix: stop ignoring NODE_TLS_REJECT_UNAUTHORIZED when strictSSL is not defined

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -11,7 +11,12 @@ const conditionalHeaders = [
 const configureOptions = (opts) => {
   const { strictSSL, ...options } = { ...opts }
   options.method = options.method ? options.method.toUpperCase() : 'GET'
-  options.rejectUnauthorized = strictSSL !== false
+
+  if (strictSSL === undefined || strictSSL === null) {
+    options.rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0'
+  } else {
+    options.rejectUnauthorized = strictSSL !== false
+  }
 
   if (!options.retry) {
     options.retry = { retries: 0 }

--- a/test/options.js
+++ b/test/options.js
@@ -82,6 +82,30 @@ t.test('configure options', async (t) => {
       'should treat strictSSL: null as true just like tls.connect')
   })
 
+  t.test('when NODE_TLS_REJECT_UNAUTHORIZED is defined', async (t) => {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+
+    t.same(configureOptions({ }).rejectUnauthorized, false,
+      'should return rejectUnauthorized false when NODE_TLS_REJECT_UNAUTHORIZED="0" ' +
+      'and strictSSL is undefined')
+
+    t.same(configureOptions({ strictSSL: null }).rejectUnauthorized, false,
+      'should return rejectUnauthorized false when NODE_TLS_REJECT_UNAUTHORIZED="0" ' +
+      'and strictSSL is null')
+
+    t.same(configureOptions({ strictSSL: true }).rejectUnauthorized, true,
+      'should return rejectUnauthorized true when NODE_TLS_REJECT_UNAUTHORIZED="0" ' +
+      'and strictSSL is true')
+
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'
+
+    t.same(configureOptions({ strictSSL: false }).rejectUnauthorized, false,
+      'should return rejectUnauthorized false when NODE_TLS_REJECT_UNAUTHORIZED="1" ' +
+      'and strictSSL is false')
+
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = undefined
+  })
+
   t.test('should set dns property correctly', async (t) => {
     t.test('no property given', async (t) => {
       const actualOpts = { method: 'GET' }


### PR DESCRIPTION
Currently NODE_TLS_REJECT_UNAUTHORIZED is simply ignored as options.rejectUnauthorized is always set to false when strictSSL is not defined.

Most notably this causes issues for users behind corporate proxies using npm and pnpm when installing a package that uses node-gyp. Example: https://github.com/nodejs/node-gyp/issues/2663

This change only takes into account NODE_TLS_REJECT_UNAUTHORIZED when strictSSL is not passed to fetch.

unit tests were added to ensure strictSSL is still the primary driver.