### PR TITLE
deps: negotiator@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "minipass-fetch": "^4.0.0",
     "minipass-flush": "^1.0.5",
     "minipass-pipeline": "^1.2.4",
-    "negotiator": "^0.6.3",
+    "negotiator": "^1.0.0",
     "proc-log": "^5.0.0",
     "promise-retry": "^2.0.1",
     "ssri": "^12.0.0"


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
jshttp/negotiator released 1.0.0, equivalent to 0.x but dropping support for Node <18, which are not supported by make-fetch-happen either.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
https://github.com/jshttp/negotiator/releases/tag/v1.0.0