### PR TITLE
fix: add @npmcli/redact for URL logging in fetch retries

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -3,6 +3,7 @@ const fetch = require('minipass-fetch')
 const { promiseRetry } = require('@gar/promise-retry')
 const ssri = require('ssri')
 const { log } = require('proc-log')
+const { redact: cleanUrl } = require('@npmcli/redact')
 
 const CachingMinipassPipeline = require('./pipeline.js')
 const { getAgent } = require('@npmcli/agent')
@@ -55,6 +56,7 @@ const remoteFetch = (request, options) => {
 
   return promiseRetry(async (retryHandler, attemptNum) => {
     const req = new fetch.Request(request, _opts)
+    const url = cleanUrl(req.url)
     try {
       let res = await fetch(req, _opts)
       if (_opts.integrity && res.status === 200) {
@@ -92,7 +94,7 @@ const remoteFetch = (request, options) => {
         }
 
         /* eslint-disable-next-line max-len */
-        log.http('fetch', `${req.method} ${req.url} attempt ${attemptNum} failed with ${res.status}`)
+        log.http('fetch', `${req.method} ${url} attempt ${attemptNum} failed with ${res.status}`)
         return retryHandler(res)
       }
 
@@ -116,7 +118,7 @@ const remoteFetch = (request, options) => {
         options.onRetry(err)
       }
 
-      log.http('fetch', `${req.method} ${req.url} attempt ${attemptNum} failed with ${err.code}`)
+      log.http('fetch', `${req.method} ${url} attempt ${attemptNum} failed with ${err.code}`)
       return retryHandler(err)
     }
   }, options.retry).catch((err) => {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@gar/promise-retry": "^1.0.0",
     "@npmcli/agent": "^4.0.0",
+    "@npmcli/redact": "^4.0.0",
     "cacache": "^20.0.1",
     "http-cache-semantics": "^4.1.1",
     "minipass": "^7.0.2",


### PR DESCRIPTION

export NPM_CONFIG_REGISTRY=https://user:password@artifactory.com.au

While installing npm package, in retry scenario, its logging credentials in the console. Raise the pull request to cleanurl before logging it so auth details are not logged.

Similar approach followed in npm-registry-fetch as well. 