### PR TITLE
chore: tolerate cacache CACHEDIR.TAG and EEXIST from cacache >= 21.0.1

### DIFF
--- a/test/cacheable-response-invalid-integrity.js
+++ b/test/cacheable-response-invalid-integrity.js
@@ -37,6 +37,8 @@ t.test('cacheable request with invalid integrity', async t => {
 
   await t.rejects(res.json(), { code: 'EINTEGRITY' })
   t.ok(req.isDone())
-  const dir = await readdir(cache)
+  // cacache writes a CACHEDIR.TAG marker when it creates the cache dir; the
+  // important thing is that no cache entry (content-v2/index-v2) was written
+  const dir = (await readdir(cache)).filter((file) => file !== 'CACHEDIR.TAG')
   t.same(dir, ['tmp'], 'did not write to cache, only temp')
 })

--- a/test/inaccessible-cache.js
+++ b/test/inaccessible-cache.js
@@ -19,6 +19,9 @@ t.test('catches error for inaccessible cache', async t => {
     cachePath: path.resolve(cache, 'file'),
   })
 
-  await t.rejects(res.text(), { code: 'ENOTDIR' })
+  // depending on the cacache version, creating the cache dir over a file
+  // surfaces as ENOTDIR (older) or EEXIST (cacache >= 21.0.1, which mkdir's
+  // the cache dir first); either way the inaccessible cache must reject
+  await t.rejects(res.text(), { code: /^(ENOTDIR|EEXIST)$/ })
   t.ok(req.isDone())
 })


### PR DESCRIPTION
cacache 21.0.1 now writes a CACHEDIR.TAG marker when it creates a cache directory and mkdir's the cache dir before use. This added an extra entry to the cache dir and changed the inaccessible-cache error from ENOTDIR to EEXIST, breaking two assertions without any real behavior regression. Filter the marker out of the readdir assertion and accept either errno.
