### PR TITLE
fix: strip credentials on cross-origin redirects

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -61,10 +61,12 @@ const getRedirect = (request, response, options) => {
    * governing permissions and limitations under the License.
    */
 
-  // Remove authorization if changing hostnames (but not if just
-  // changing ports or protocols).  This matches the behavior of request:
-  // https://github.com/request/request/blob/b12a6245/lib/redirect.js#L134-L138
-  if (new url.URL(request.url).hostname !== redirectUrl.hostname) {
+  // Remove authorization and cookie headers if changing origins, including
+  // ports or protocols.
+  // This prevents credentials from crossing an origin boundary while
+  // preserving them for redirects within the same origin. This intentionally
+  // tightens the legacy hostname-only behavior.
+  if (new url.URL(request.url).origin !== redirectUrl.origin) {
     request.headers.delete('authorization')
     request.headers.delete('cookie')
   }

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -373,6 +373,40 @@ t.test('removes cookie header if changing hostnames', async (t) => {
   t.notOk(httpsSrv.isDone(), 'redirect request does not happen')
 })
 
+t.test('removes authorization and cookie headers if changing ports', async (t) => {
+  const httpSrv = nock(HOST, {
+    reqheaders: {
+      authorization: 'test',
+      cookie: 'test=true',
+    },
+  })
+    .get('/redirect')
+    .reply(301, '', { Location: `${HOST}:4443/test` })
+
+  const targetSrv = nock(`${HOST}:4443`, {
+    reqheaders: {
+      authorization: 'test',
+      cookie: 'test=true',
+    },
+  })
+    .get('/test')
+    .reply(200, () => {
+      t.equal(true, false, 'meaningful failure, this should never be executed')
+      return CONTENT
+    })
+
+  await t.rejects(
+    fetch(`${HOST}/redirect`, {
+      headers: { authorization: 'test', cookie: 'test=true' },
+    }),
+    {
+      code: 'ERR_NOCK_NO_MATCH',
+    }
+  )
+  t.ok(httpSrv.isDone())
+  t.notOk(targetSrv.isDone(), 'redirect request does not happen')
+})
+
 t.test('supports passthrough of options on redirect', async (t) => {
   const httpSrv = nock(HTTPHOST)
     .get('/redirect')


### PR DESCRIPTION
Fixes #375

## Summary

- Compare normalized URL origins instead of hostnames when following redirects.
- Strip `authorization` and `cookie` when the scheme, hostname, or effective port changes.
- Preserve those headers for redirects that remain within the same origin.
- Add regression coverage for a same-hostname redirect to a different port.

## Testing

- `node_modules\.bin\tap.cmd --no-check-coverage test/fetch.js` — 161 assertions passed; 2 unrelated tests skipped.

## Compatibility note

This intentionally tightens the legacy hostname-only credential-forwarding policy. Same-origin behavior is preserved.